### PR TITLE
[feat][BE] 분석 결과 Firestore 저장 로직 구현 (#25)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,18 +1,20 @@
-from fastapi import FastAPI, UploadFile, File
+from fastapi import FastAPI
 from dotenv import load_dotenv
 
 load_dotenv()
 
 from app.routes.ocr_routes import router as ocr_router
 
-app = FastAPI()
+app = FastAPI(
+    title="OPSW Backend",
+    description="OCR → AI → Firestore Pipeline",
+    version="1.0.0"
+)
+
+# OCR + AI + Save 라우터 포함
 app.include_router(ocr_router)
+
 
 @app.get("/")
 def root():
     return {"msg": "Backend is running"}
-
-@app.post("/ocr")
-async def upload_image(file: UploadFile = File(...)):
-    return {"filename": file.filename}
-

--- a/backend/app/routes/ocr_routes.py
+++ b/backend/app/routes/ocr_routes.py
@@ -3,22 +3,28 @@ from app.services.ocr_service import extract_text_from_image
 from app.utils.parser import parse_ocr_text
 from app.services.drug_enrichment import enrich_ocr_drugs
 
-
 from app.services.ollama_service import analyze_ocr_text_with_llm
+
+# Firestore 저장 로직
+from app.services.firestore_store import (
+    save_scan,
+    save_medicines,
+    save_prescription,
+    save_schedules
+)
 
 router = APIRouter(prefix="/api/ocr", tags=["OCR"])
 
 
-# -------------------------
-# 1) OCR 업로드
-# -------------------------
+# ----------------------------------------------------
+# 1) 기본 OCR 업로드
+# ----------------------------------------------------
 @router.post("/upload")
 async def upload_image(file: UploadFile = File(...)):
     try:
         file_bytes = await file.read()
 
         raw_text = extract_text_from_image(file_bytes)
-
         parsed = parse_ocr_text(raw_text)
 
         return {
@@ -33,22 +39,20 @@ async def upload_image(file: UploadFile = File(...)):
         print("OCR ERROR:", e)
         raise HTTPException(status_code=500, detail=str(e))
 
-'''
+
 # ----------------------------------------------------
-# 2) FULL OCR + 약 API 검색 
+# 2) FULL OCR + 약 정보 API (보류 기능, 유지)
 # ----------------------------------------------------
+"""
 @router.post("/upload/full")
 async def upload_image_with_drug_info(file: UploadFile = File(...)):
     try:
         file_bytes = await file.read()
 
-        # OCR
         raw_text = extract_text_from_image(file_bytes)
 
-        # 파싱 (약명, 용량, 횟수 등)
         parsed = parse_ocr_text(raw_text)
 
-        # 약 검색 + 효능/주의/부작용 포함한 enrichment
         drug_details = enrich_ocr_drugs(parsed["drugs"])
 
         return {
@@ -61,20 +65,17 @@ async def upload_image_with_drug_info(file: UploadFile = File(...)):
     except Exception as e:
         print("OCR+Drug ERROR:", e)
         raise HTTPException(status_code=500, detail=str(e))
-'''
-
+"""
 # ----------------------------------------------------
-# 3)  OCR + Ollama AI 분석
+# 3) OCR + Ollama AI 분석 (약명 정규화 JSON)
 # ----------------------------------------------------
 @router.post("/upload/ai")
 async def upload_image_with_ai(file: UploadFile = File(...)):
     try:
         file_bytes = await file.read()
 
-        # 1) OCR
         raw_text = extract_text_from_image(file_bytes)
 
-        # 2) Ollama 분석 (약명 정규화 + 용량 추출 + JSON)
         ai_parsed = analyze_ocr_text_with_llm(raw_text)
 
         return {
@@ -85,4 +86,44 @@ async def upload_image_with_ai(file: UploadFile = File(...)):
 
     except Exception as e:
         print("OCR+AI ERROR:", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ----------------------------------------------------
+# 4) OCR + AI 분석 + Firestore 저장 (최종 파이프라인)
+# ----------------------------------------------------
+@router.post("/upload/ai/save")
+async def upload_image_ai_and_save(file: UploadFile = File(...)):
+    try:
+        # 임시 user_id → 추후 FE 인증 연동 예정
+        user_id = "test_user_001"
+
+        file_bytes = await file.read()
+
+        # 1) OCR
+        raw_text = extract_text_from_image(file_bytes)
+
+        # 2) AI 분석(JSON, 약 구조 파싱)
+        ai_parsed = analyze_ocr_text_with_llm(raw_text)
+        medications = ai_parsed.get("drugs", [])
+
+        # 3) Firestore 저장
+        scan_id = save_scan(user_id, raw_text, ai_parsed)
+        medicine_ids = save_medicines(user_id, scan_id, medications)
+        prescription_id = save_prescription(user_id, scan_id, medicine_ids)
+        schedule_ids = save_schedules(user_id, medicine_ids, medications)
+
+        return {
+            "success": True,
+            "message": "OCR + AI 분석 + Firestore 저장 완료",
+            "scan_id": scan_id,
+            "prescription_id": prescription_id,
+            "medicine_ids": medicine_ids,
+            "schedule_ids": schedule_ids,
+            "raw_text": raw_text,
+            "ai_parsed": ai_parsed,
+        }
+
+    except Exception as e:
+        print("FULL PIPELINE ERROR:", e)
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/services/firestore_store.py
+++ b/backend/app/services/firestore_store.py
@@ -1,0 +1,100 @@
+from google.cloud import firestore
+from datetime import datetime, timedelta, timezone
+import os
+import uuid
+
+db = firestore.Client.from_service_account_json(
+    os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+)
+
+# ---------------------------
+# 1. OCR 원본 저장
+# ---------------------------
+def save_scan(user_id: str, raw_text: str, ai_parsed: dict):
+    scan_ref = db.collection("prescription_scans").document()
+    scan_ref.set({
+        "user_id": user_id,
+        "raw_ocr_text": raw_text,
+        "parsed": True,
+        "created_at": datetime.now(timezone.utc),
+    })
+    return scan_ref.id
+
+
+# ---------------------------
+# 2. 약 리스트 저장 (약 ID 만 생성)
+# ---------------------------
+def save_medicines(user_id: str, scan_id: str, medications: list):
+    medicine_ids = [str(uuid.uuid4()) for _ in medications]
+    return medicine_ids
+
+
+# ---------------------------
+# 3. 처방전 저장
+# ---------------------------
+def save_prescription(user_id: str, scan_id: str, medicines: list):
+    prescription_id = str(uuid.uuid4())
+
+    doc = {
+        "user_id": user_id,
+        "scan_id": scan_id,
+        "created_at": datetime.utcnow(),
+        "medicine_ids": medicines,
+    }
+
+    db.collection("prescriptions").document(prescription_id).set(doc)
+    return prescription_id
+
+
+# ---------------------------
+# 4. 복용 스케줄 저장
+# ---------------------------
+def save_schedules(user_id: str, medicine_ids: list, medications: list):
+    schedule_ids = []
+
+    for idx, med in enumerate(medications):
+
+        med_id = medicine_ids[idx]
+
+        # === 정규화 ===
+        # times_per_day
+        tpd = med.get("times_per_day", "1회")
+        if isinstance(tpd, str):
+            tpd = int(tpd.replace("회", ""))
+
+        # days
+        days = med.get("days", "1일")
+        if isinstance(days, str):
+            days = int(days.replace("일", ""))
+
+        # 복용 시간 자동 생성
+        if tpd == 1:
+            times = ["09:00"]
+        elif tpd == 2:
+            times = ["09:00", "18:00"]
+        elif tpd == 3:
+            times = ["09:00", "13:00", "18:00"]
+        else:
+            times = ["09:00"]
+
+        # start_date (처방일이 OCR에 있으면 사용)
+        start_date = datetime.utcnow()
+
+        schedule_id = str(uuid.uuid4())
+
+        schedule_doc = {
+            "user_id": user_id,
+            "medicine_id": med_id,
+            "drug_name": med.get("drug_name"),
+            "dose": med.get("dose"),
+            "times_per_day": tpd,
+            "days": days,
+            "times": times,
+            "start_date": start_date,
+            "end_date": start_date + timedelta(days=days),
+        }
+
+        db.collection("schedules").document(schedule_id).set(schedule_doc)
+        schedule_ids.append(schedule_id)
+
+    return schedule_ids


### PR DESCRIPTION
## 개요
OCR → AI 분석(Ollama) → Firestore 저장까지 이어지는 전체 파이프라인을 구축하였다.

약 데이터(drugs), 스케줄(schedules), 스캔 정보(prescription_scans), 처방전(prescriptions)을 자동 생성한다.

---

## 변경 사항

### 1. OCR + AI 분석 라우터 추가
- `/api/ocr/upload/ai/save`
- OCR 수행 후 → AI 분석(Ollama) → Firestore 저장까지 자동 처리

### 2. Firestore 저장 구조 구현
- elders/users 기반 user_id 적용
- `prescription_scans` 작성
- `prescriptions` 문서 생성
- `medicines`는 별도 컬렉션 대신 prescriptions 내 ID 참조 방식 적용
- `schedules` 자동 생성

### 3. 자동 스케줄 생성 로직
- 하루 1~3회 복용 시간 자동 배정
- “2회 → 2”, “3회 → 3”과 같은 정규화 처리
- “3일” 같은 문자열 → 정수 변환
- 시작일(start_date) 자동 생성 (추후 OCR에서 날짜 추출 시 연동 가능)

---

## 수정된 파일
- `app/routes/ocr_routes.py`
- `app/services/firestore_store.py`
- `main.py`


## 리뷰어 참고 사항
- AI 분석 JSON 구조가 확정되면 times_per_day, days 정규화 로직 개선 가능
- schedule 생성 시간이 증가할 수 있으나 비동기로 분리 예정
