### PR TITLE
[feat][BE] 보호자–사용자 연결 관리 API 구현 (#57)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,12 @@
-from fastapi import FastAPI
 from dotenv import load_dotenv
+load_dotenv() 
 
-load_dotenv()
+from fastapi import FastAPI
 
 from app.routes.ocr_routes import router as ocr_router
+from app.routes.alert_routes import router as alert_router
+from app.routes.guardian_routes import router as guardian_router
+# from app.routes.schedule_routes import router as schedule_router
 
 app = FastAPI(
     title="OPSW Backend",
@@ -11,9 +14,16 @@ app = FastAPI(
     version="1.0.0"
 )
 
-# OCR + AI + Save 라우터 포함
+# OCR + AI + Save
 app.include_router(ocr_router)
 
+# 복약 알림
+app.include_router(alert_router)
+
+# 보호자-사용자 연결 관리
+app.include_router(guardian_router)
+
+# app.include_router(schedule_router)
 
 @app.get("/")
 def root():

--- a/backend/app/routes/guardian_routes.py
+++ b/backend/app/routes/guardian_routes.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Body, Query
+from app.services.guardian_service import (
+    link_guardian,
+    get_guardians_by_user,
+    unlink_guardian
+)
+
+router = APIRouter(
+    prefix="/api/guardians",
+    tags=["Guardians"]
+)
+
+
+@router.post("/link")
+def link_guardian_api(
+    user_id: str = Body(...),
+    guardian_id: str = Body(...)
+):
+    """
+    보호자 연결
+    """
+    return link_guardian(user_id, guardian_id)
+
+
+@router.get("")
+def get_guardians_api(
+    user_id: str = Query(...)
+):
+    """
+    사용자 기준 보호자 목록 조회
+    """
+    return get_guardians_by_user(user_id)
+
+
+@router.delete("/link")
+def unlink_guardian_api(
+    user_id: str = Body(...),
+    guardian_id: str = Body(...)
+):
+    """
+    보호자 연결 해제
+    """
+    return unlink_guardian(user_id, guardian_id)

--- a/backend/app/services/guardian_service.py
+++ b/backend/app/services/guardian_service.py
@@ -1,0 +1,82 @@
+from google.cloud import firestore
+from datetime import datetime, timezone
+import os
+
+db = firestore.Client.from_service_account_json(
+    os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+)
+
+
+def link_guardian(user_id: str, guardian_id: str):
+    """
+    사용자 ↔ 보호자 연결
+    (중복 방지)
+    """
+    existing = (
+        db.collection("user_guardians")
+        .where("user_id", "==", user_id)
+        .where("guardian_id", "==", guardian_id)
+        .limit(1)
+        .stream()
+    )
+
+    if any(existing):
+        return {"status": "already_linked"}
+
+    db.collection("user_guardians").add({
+        "user_id": user_id,
+        "guardian_id": guardian_id,
+        "created_at": datetime.now(timezone.utc)
+    })
+
+    return {"status": "linked"}
+
+
+def get_guardians_by_user(user_id: str):
+    """
+    사용자 기준 보호자 목록 조회
+    """
+    links = (
+        db.collection("user_guardians")
+        .where("user_id", "==", user_id)
+        .stream()
+    )
+
+    guardians = []
+
+    for link in links:
+        guardian_id = link.to_dict()["guardian_id"]
+        guardian_doc = db.collection("guardians").document(guardian_id).get()
+
+        if guardian_doc.exists:
+            data = guardian_doc.to_dict()
+            guardians.append({
+                "guardian_id": guardian_id,
+                "name": data.get("name"),
+                "phone": data.get("phone"),
+                "fcm_token_exists": bool(data.get("fcm_token"))
+            })
+
+    return {"guardians": guardians}
+
+
+def unlink_guardian(user_id: str, guardian_id: str):
+    """
+    보호자 연결 해제
+    """
+    links = (
+        db.collection("user_guardians")
+        .where("user_id", "==", user_id)
+        .where("guardian_id", "==", guardian_id)
+        .stream()
+    )
+
+    deleted = False
+    for link in links:
+        link.reference.delete()
+        deleted = True
+
+    if not deleted:
+        return {"status": "not_found"}
+
+    return {"status": "unlinked"}


### PR DESCRIPTION
## 개요
보호자와 사용자 간의 관계를 Firestore 기반으로 관리할 수 있도록
핵심 연결 관리 API를 구현했습니다.

---

## 변경 사항
- 보호자–사용자 연결 API 구현 (POST `/api/guardians/link`)
- 보호자–사용자 연결 해제 API 구현 (DELETE `/api/guardians/link`)
- 사용자 기준 보호자 목록 조회 API 구현 (GET `/api/guardians`)
- Firestore `user_guardians` 컬렉션을 통한 관계 관리

---

## 관련 이슈
closes #57

---

## 리뷰어 참고 사항
- 보호자 정보는 `guardians` 컬렉션에서 관리되며  
  사용자–보호자 연결 정보는 `user_guardians` 컬렉션에 저장됩니다.
- 본 PR은 **보호자–사용자 관계 관리의 백엔드 핵심 로직 구현**까지를 범위로 합니다.
- 이후 보호자 알림(FCM) 기능과 자연스럽게 연동되는 구조입니다.
