### PR TITLE
[feat][FE]: 복약(Intake) 핵심 로직 구현 및 Firestore 연동 (#18, #20)

### DIFF
--- a/frontend/app/lib/home_screens.dart
+++ b/frontend/app/lib/home_screens.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+
 import 'models.dart';
 import 'services.dart';
+import 'enums.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -18,11 +20,18 @@ class HomeScreen extends StatelessWidget {
     return StreamBuilder<List<Senior>>(
       stream: eldersStream(),
       builder: (context, snapshot) {
-        if (!snapshot.hasData) {
-          return const Center(child: CircularProgressIndicator());
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        if (snapshot.hasError) {
+          return Scaffold(
+            body: Center(child: Text('에러: ${snapshot.error}')),
+          );
         }
 
-        final seniors = snapshot.data!;
+        final seniors = snapshot.data ?? [];
 
         return Scaffold(
           appBar: AppBar(title: const Text('시니어 관리')),
@@ -31,13 +40,25 @@ class HomeScreen extends StatelessWidget {
             itemCount: seniors.length,
             itemBuilder: (context, index) {
               final s = seniors[index];
+
               return Card(
-                child: ListTile(
-                  title: Text(s.name),
-                  subtitle: Text('보호자: ${s.guardianName}'),
-                  trailing: IconButton(
-                    icon: const Icon(Icons.delete),
-                    onPressed: () => deleteSenior(s.id),
+                margin: const EdgeInsets.only(bottom: 12),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    children: [
+                      ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(s.name),
+                        subtitle: Text('보호자: ${s.guardianName}'),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () => deleteSenior(s.id),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      intakeButtons(context, s),
+                    ],
                   ),
                 ),
               );
@@ -68,6 +89,16 @@ class _AddSeniorSheetState extends State<AddSeniorSheet> {
   final _gPhone = TextEditingController();
 
   @override
+  void dispose() {
+    _name.dispose();
+    _birth.dispose();
+    _phone.dispose();
+    _gName.dispose();
+    _gPhone.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.only(
@@ -76,31 +107,90 @@ class _AddSeniorSheetState extends State<AddSeniorSheet> {
         bottom: MediaQuery.of(context).viewInsets.bottom + 16,
         top: 16,
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          TextField(controller: _name, decoration: const InputDecoration(labelText: '이름')),
-          TextField(controller: _birth, decoration: const InputDecoration(labelText: '생년월일')),
-          TextField(controller: _phone, decoration: const InputDecoration(labelText: '전화번호')),
-          const Divider(),
-          TextField(controller: _gName, decoration: const InputDecoration(labelText: '보호자 이름')),
-          TextField(controller: _gPhone, decoration: const InputDecoration(labelText: '보호자 전화번호')),
-          const SizedBox(height: 20),
-          ElevatedButton(
-            onPressed: () async {
-              await addSenior(
-                name: _name.text,
-                birth: _birth.text,
-                phone: _phone.text,
-                guardianName: _gName.text,
-                guardianPhone: _gPhone.text,
-              );
-              Navigator.pop(context);
-            },
-            child: const Text('저장'),
-          ),
-        ],
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _name,
+              decoration: const InputDecoration(labelText: '이름'),
+            ),
+            TextField(
+              controller: _birth,
+              decoration: const InputDecoration(labelText: '생년월일'),
+            ),
+            TextField(
+              controller: _phone,
+              decoration: const InputDecoration(labelText: '전화번호'),
+            ),
+            const Divider(),
+            TextField(
+              controller: _gName,
+              decoration: const InputDecoration(labelText: '보호자 이름'),
+            ),
+            TextField(
+              controller: _gPhone,
+              decoration: const InputDecoration(labelText: '보호자 전화번호'),
+            ),
+            const SizedBox(height: 20),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () async {
+                  await addSenior(
+                    name: _name.text,
+                    birth: _birth.text,
+                    phone: _phone.text,
+                    guardianName: _gName.text,
+                    guardianPhone: _gPhone.text,
+                  );
+                  if (context.mounted) Navigator.pop(context);
+                },
+                child: const Text('저장'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
+}
+
+Widget intakeButtons(BuildContext context, Senior s) {
+  return StreamBuilder<Map<IntakeSlot, IntakeStatus>>(
+    stream: todayIntakeStream(s.id),
+    builder: (context, snapshot) {
+      final data = snapshot.data ??
+          {
+            IntakeSlot.morning: IntakeStatus.none,
+            IntakeSlot.lunch: IntakeStatus.none,
+            IntakeSlot.dinner: IntakeStatus.none,
+          };
+
+      ElevatedButton btn(String label, IntakeSlot slot) {
+        final current = data[slot] ?? IntakeStatus.none;
+
+        return ElevatedButton(
+          onPressed: () async {
+            await saveIntake(
+              elderId: s.id,
+              date: DateTime.now(),
+              slot: slot,
+              status: IntakeStatus.taken,
+            );
+          },
+          child: Text('$label (${current.name})'),
+        );
+      }
+
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          btn('아침', IntakeSlot.morning),
+          btn('점심', IntakeSlot.lunch),
+          btn('저녁', IntakeSlot.dinner),
+        ],
+      );
+    },
+  );
 }

--- a/frontend/app/lib/services.dart
+++ b/frontend/app/lib/services.dart
@@ -1,11 +1,38 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'models.dart';
 
-final _db = FirebaseFirestore.instance;
+import 'models.dart';
+import 'enums.dart';
+
+final FirebaseFirestore _db = FirebaseFirestore.instance;
+final FirebaseAuth _auth = FirebaseAuth.instance;
+
+/* ────────────────────────────
+   User
+   ──────────────────────────── */
+
+Future<void> ensureUserDoc() async {
+  final user = _auth.currentUser;
+  if (user == null) return;
+
+  final ref = _db.collection('users').doc(user.uid);
+  final snap = await ref.get();
+
+  if (!snap.exists) {
+    await ref.set({
+      'email': user.email ?? '',
+      'role': 'caregiver',
+      'created_at': FieldValue.serverTimestamp(),
+    });
+  }
+}
+
+/* ────────────────────────────
+   Elders (CRUD)
+   ──────────────────────────── */
 
 Stream<List<Senior>> eldersStream() {
-  final uid = FirebaseAuth.instance.currentUser!.uid;
+  final uid = _auth.currentUser!.uid;
 
   return _db
       .collection('elders')
@@ -25,7 +52,7 @@ Future<void> addSenior({
   required String guardianName,
   required String guardianPhone,
 }) async {
-  final uid = FirebaseAuth.instance.currentUser!.uid;
+  final uid = _auth.currentUser!.uid;
 
   await _db.collection('elders').add({
     'user_id': uid,
@@ -38,6 +65,79 @@ Future<void> addSenior({
   });
 }
 
-Future<void> deleteSenior(String id) async {
-  await _db.collection('elders').doc(id).delete();
+Future<void> deleteSenior(String elderId) async {
+  await _db.collection('elders').doc(elderId).delete();
+}
+
+/* ────────────────────────────
+   Intake Logs
+   ──────────────────────────── */
+
+Future<void> saveIntake({
+  required String elderId,
+  required DateTime date,
+  required IntakeSlot slot,
+  required IntakeStatus status,
+}) async {
+  final uid = _auth.currentUser!.uid;
+
+  final dayKey =
+      '${date.year}${date.month.toString().padLeft(2, '0')}${date.day.toString().padLeft(2, '0')}';
+
+  final docId = '${elderId}_${dayKey}_${slot.name}';
+
+  await _db.collection('intake_logs').doc(docId).set({
+    'user_id': uid,
+    'elder_id': elderId,
+    'date': Timestamp.fromDate(date),
+    'slot': slot.name,
+    'status': status.name,
+    'updated_at': FieldValue.serverTimestamp(),
+  }, SetOptions(merge: true));
+}
+
+Stream<Map<IntakeSlot, IntakeStatus>> todayIntakeStream(String elderId) {
+  final now = DateTime.now();
+  final start = DateTime(now.year, now.month, now.day);
+  final end = start.add(const Duration(days: 1));
+
+  final startTs = Timestamp.fromDate(start);
+  final endTs = Timestamp.fromDate(end);
+
+  return _db
+      .collection('intake_logs')
+      .where('elder_id', isEqualTo: elderId)
+      .where('date', isGreaterThanOrEqualTo: startTs)
+      .where('date', isLessThan: endTs)
+      .snapshots()
+      .map((snap) {
+        final result = <IntakeSlot, IntakeStatus>{
+          IntakeSlot.morning: IntakeStatus.none,
+          IntakeSlot.lunch: IntakeStatus.none,
+          IntakeSlot.dinner: IntakeStatus.none,
+        };
+
+        for (final doc in snap.docs) {
+          final data = doc.data();
+
+          final slotStr = data['slot'] as String?;
+          final statusStr = data['status'] as String?;
+
+          if (slotStr == null || statusStr == null) continue;
+
+          final slot = IntakeSlot.values.firstWhere(
+            (e) => e.name == slotStr,
+            orElse: () => IntakeSlot.morning,
+          );
+
+          final status = IntakeStatus.values.firstWhere(
+            (e) => e.name == statusStr,
+            orElse: () => IntakeStatus.none,
+          );
+
+          result[slot] = status;
+        }
+
+        return result;
+      });
 }


### PR DESCRIPTION
## 개요
복약(Intake) 기능의 핵심 로직을 구현하고,
Firestore 기반 저장 및 조회 구조를 정리했습니다.

---

## 변경 사항
- intake_logs 컬렉션 기반 복약 기록 저장 로직 구현
- 날짜 + 복약 시간대(slot) 기준 문서 ID 설계
- 오늘 기준 복약 상태 조회 Stream 제공
- FE에서 재사용 가능한 service 형태로 정리

---

## 관련 이슈
- closes #18 #20 

---

## 👀 리뷰어 참고 사항
- UI / 캘린더 / 리포트 기능은 본 PR의 로직을 기반으로 확장 예정
- 복약 데이터 구조는 추후 BE/OCR 파이프라인과 연동 가능